### PR TITLE
Tree view, make expandable only entries with subfolders

### DIFF
--- a/src/ptk/ptk-dir-tree.c
+++ b/src/ptk/ptk-dir-tree.c
@@ -556,6 +556,23 @@ gint ptk_dir_tree_node_compare( PtkDirTree* tree,
     return ret;
 }
 
+/* Checks if path has at least one subfolder */
+gboolean path_has_dirs(const char * path) {
+  gboolean ret = FALSE;
+  const char * name = NULL;
+  char * file_path = NULL;
+  GDir *dir = g_dir_open( path, 0, NULL );
+  if( dir ) {
+        while(!ret && (name = g_dir_read_name( dir )) ) {
+            file_path = g_build_filename( path, name, NULL );
+            if( g_file_test( file_path, G_FILE_TEST_IS_DIR )) ret = TRUE;
+            g_free(file_path);
+        }
+        g_dir_close( dir );
+  }
+  return ret;
+}
+
 PtkDirTreeNode* ptk_dir_tree_node_new( PtkDirTree* tree,
                                        PtkDirTreeNode* parent,
                                        const char* path,
@@ -569,9 +586,11 @@ PtkDirTreeNode* ptk_dir_tree_node_new( PtkDirTree* tree,
     {
         node->file = vfs_file_info_new();
         vfs_file_info_get( node->file, path, base_name );
-        node->n_children = 0;
-        node->children = ptk_dir_tree_node_new( tree, node, NULL, NULL );
-        node->last = node->children;
+        if (path_has_dirs(path)) { //Check if path has subfolders, only expandable nodes will have the little arrow :)
+            node->n_children = 1;
+            node->children = ptk_dir_tree_node_new( tree, node, NULL, NULL );
+            node->last = node->children;
+        }
     }
     return node;
 }


### PR DESCRIPTION
Currently, all folders are expandable, and those without subfolders show a "( no subfolder )" item. With this patch, only folders with subfolders are expandable.

I always wanted this one, now instead of asking for it I tried this "GIT" thing and coded it :)

Now regarding technical aspects: when browsing a directory now spacefm would "peep-read" every subfolder inside it to check if they also have at least one subfolder. This might look like a drawback, (okay, it IS a drawback) but think of all the time you spend (or at least I spent) checking for empty folders in search of a subdirectory!!! I don't think it's a performance issue anyway, since it will quit the loop just after finding the first subfolder, this new feature could be optional anyway.

The "( no subfolder )" option is still there (ptk_dir_tree_get_value), I'll look deeper into it to check if it's needed for something else, afaik it isn't.

P.S. There's one "test commit" I made by mistake, please ignore that one, I'll research on how to delete bad commits in the meantime :)
