### PR TITLE
Change from uppercase to lowercase the first letter of the progress prop...

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -774,7 +774,7 @@ void show_socket_help()
     printf( "folder                          %s\n", _("text to show in Folder task column") );
     printf( "item                            %s\n", _("text to show in Item task column") );
     printf( "to                              %s\n", _("text to show in To task column") );
-    printf( "progress                        %s\n", _("Progress percent (1..100) or '' to pulse") );
+    printf( "progress                        %s\n", _("progress percent (1..100) or '' to pulse") );
     printf( "total                           %s\n", _("text to show in Total task column") );
     printf( "curspeed                        %s\n", _("text to show in Current task column") );
     printf( "curremain                       %s\n", _("text to show in CRemain task column") );


### PR DESCRIPTION
The progress property definition is the only one beginning with an uppercase letter, so I changed it for a lowercase letter:

```
TASK PROPERTIES
---------------
status                          contents of Status task column  (read-only)
icon                            eg 'gtk-open'
count                           text to show in Count task column
folder                          text to show in Folder task column
item                            text to show in Item task column
to                              text to show in To task column
progress                        Progress percent (1..100) or '' to pulse
total                           text to show in Total task column
curspeed                        text to show in Current task column
curremain                       text to show in CRemain task column
avgspeed                        text to show in Average task column
avgremain                       text to show in Remain task column
elapsed                         contents of Elapsed task column (read-only)
started                         contents of Started task column (read-only)
queue_state                     run|pause|queue|stop
popup_handler                   COMMAND  command to show a custom task dialog
```
