### PR TITLE
Skip thumbnail generation for skinny images

### DIFF
--- a/src/vfs/vfs-thumbnail-loader.c
+++ b/src/vfs/vfs-thumbnail-loader.c
@@ -374,15 +374,20 @@ static GdkPixbuf* _vfs_thumbnail_load( const char* file_path, const char* uri,
     {
         if( thumbnail )
             g_object_unref( thumbnail );
-        /* create new thumbnail */
-        thumbnail = gdk_pixbuf_new_from_file_at_size( file_path, 128, 128, NULL );
-        if ( thumbnail )
+
+        /* images with aspect ratios below 0.02 are skipped because gdk resizing would fail */
+        if ( w == h || ( w > h && (float)h / (float)w >= 0.02f ) || ( h > w && (float)w / (float)h >= 0.02f ) )
         {
-            thumbnail = gdk_pixbuf_apply_embedded_orientation( thumbnail );
-            sprintf( mtime_str, "%lu", mtime );
-            gdk_pixbuf_save( thumbnail, thumbnail_file, "png", NULL,
-                             "tEXt::Thumb::URI", uri, "tEXt::Thumb::MTime", mtime_str, NULL );
-            chmod( thumbnail_file, 0600 );  /* only the owner can read it. */
+            /* create new thumbnail */
+            thumbnail = gdk_pixbuf_new_from_file_at_size( file_path, 128, 128, NULL );
+            if ( thumbnail )
+            {
+                thumbnail = gdk_pixbuf_apply_embedded_orientation( thumbnail );
+                sprintf( mtime_str, "%lu", mtime );
+                gdk_pixbuf_save( thumbnail, thumbnail_file, "png", NULL,
+                                 "tEXt::Thumb::URI", uri, "tEXt::Thumb::MTime", mtime_str, NULL );
+                chmod( thumbnail_file, 0600 );  /* only the owner can read it. */
+            }
         }
     }
 


### PR DESCRIPTION
As an example, let's have two images: one is 1000x19 and another is 1000x20. GDK will create the thumbnail for the latter, but not for the former. There's nothing wrong with this, since such thumbnails would become pretty useless after that point.

However, thumbnail generation can sometimes take a long time for large images (like https://raw.github.com/clintbellanger/flare-game/master/mods/fantasycore/images/enemies/fire_ant.png). So instead of wasting time attempting to generate a thumbnail and eventually failing, the aspect ratio should be checked beforehand.
