### PR TITLE
Dealing with clearing up large amount of memory used by big thumbnails

### DIFF
--- a/src/pref-dialog.c
+++ b/src/pref-dialog.c
@@ -20,6 +20,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <malloc.h>
 
 #include "glib-utils.h"
 #include <glib/gi18n.h>
@@ -33,6 +34,7 @@
 #include "ptk-location-view.h"
 
 #include "gtk2-compat.h"
+
 
 typedef struct _FMPrefDlg FMPrefDlg;
 struct _FMPrefDlg
@@ -529,6 +531,11 @@ static void on_response( GtkDialog* dlg, int response, FMPrefDlg* user_data )
             }
             //if ( desktop )
                 fm_desktop_update_thumbnails();
+
+            /* Ensuring free space at the end of the heap is freed to the OS,
+             * mainly to deal with the possibility thousands of large thumbnails
+             * have been freed but the memory not actually released by SpaceFM */
+            malloc_trim(0);
         }
 
         /* icon sizes are changed? */

--- a/src/ptk/ptk-file-browser.c
+++ b/src/ptk/ptk-file-browser.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <malloc.h>
 
 #include <fcntl.h>
 
@@ -1677,6 +1678,12 @@ void ptk_file_browser_finalize( GObject *obj )
     file_browser->select_path = NULL;
     
     G_OBJECT_CLASS( parent_class ) ->finalize( obj );
+
+    /* Ensuring free space at the end of the heap is freed to the OS,
+     * mainly to deal with the possibility that killing the browser results in
+     * thousands of large thumbnails being freed, but the memory not actually
+     * released by SpaceFM */
+    malloc_trim(0);
 }
 
 void ptk_file_browser_get_property ( GObject *obj,
@@ -4896,6 +4903,11 @@ void ptk_file_browser_refresh( GtkWidget* item, PtkFileBrowser* file_browser )
 
     // destroy file list and create new one
     ptk_file_browser_update_model( file_browser );
+
+    /* Ensuring free space at the end of the heap is freed to the OS,
+     * mainly to deal with the possibility thousands of large thumbnails
+     * have been freed but the memory not actually released by SpaceFM */
+    malloc_trim(0);
 
     // begin load dir
     file_browser->dir = vfs_dir_get_by_path(

--- a/src/ptk/ptk-file-list.c
+++ b/src/ptk/ptk-file-list.c
@@ -1037,8 +1037,13 @@ void ptk_file_list_show_thumbnails( PtkFileList* list, gboolean is_big,
                 {
                     /* update the model */
                     ptk_file_list_file_changed( list->dir, file, list );
+
                 }
             }
+
+            /* Thumbnails are being disabled so ensure the large thumbnails are
+             * freed - with up to 256x256 images this is a lot of memory */
+            vfs_dir_unload_thumbnails(list->dir, is_big);
         }
         return;
     }

--- a/src/vfs/vfs-dir.c
+++ b/src/vfs/vfs-dir.c
@@ -21,11 +21,10 @@
 #include <string.h>
 
 #include <fcntl.h>  /* for open() */
+#include <malloc.h> /* for malloc_trim */
 #include <unistd.h> /* for read */
 #include "vfs-volume.h"
 
-// Debug code
-#include <malloc.h>
 
 static void vfs_dir_class_init( VFSDirClass* klass );
 static void vfs_dir_init( VFSDir* dir );

--- a/src/vfs/vfs-dir.c
+++ b/src/vfs/vfs-dir.c
@@ -24,6 +24,9 @@
 #include <unistd.h> /* for read */
 #include "vfs-volume.h"
 
+// Debug code
+#include <malloc.h>
+
 static void vfs_dir_class_init( VFSDirClass* klass );
 static void vfs_dir_init( VFSDir* dir );
 static void vfs_dir_finalize( GObject *obj );
@@ -1187,6 +1190,11 @@ void vfs_dir_unload_thumbnails( VFSDir* dir, gboolean is_big )
         }
     }
     g_mutex_unlock( dir->mutex );
+
+    /* Ensuring free space at the end of the heap is freed to the OS,
+     * mainly to deal with the possibility thousands of large thumbnails
+     * have been freed but the memory not actually released by SpaceFM */
+    malloc_trim(0);
 }
 
 //sfm added mime change timer


### PR DESCRIPTION
Thumbnails were generally being freed, but the potentially huge (GBs)
amount of space was still sat 'available' in SpaceFM's heap - have added
malloc_trim calls to flush out the free heap back to the OS when needed.

Disabling thumbnails in the preference dialog didn't cause thumbnails
to be freed so this has been sorted out too.