### PR TITLE
fix malloc_trim for non GlibC libraries

### DIFF
--- a/src/main-window.c
+++ b/src/main-window.c
@@ -1216,7 +1216,9 @@ void main_window_toggle_thumbnails_all_windows()
     /* Ensuring free space at the end of the heap is freed to the OS,
      * mainly to deal with the possibility thousands of large thumbnails
      * have been freed but the memory not actually released by SpaceFM */
-    malloc_trim(0);
+    #if defined (__GLIBC__)
+        malloc_trim(0);
+    #endif
 }
 
 void focus_panel( GtkMenuItem* item, gpointer mw, int p )

--- a/src/ptk/ptk-file-browser.c
+++ b/src/ptk/ptk-file-browser.c
@@ -1513,7 +1513,9 @@ void ptk_file_browser_finalize( GObject *obj )
      * mainly to deal with the possibility that killing the browser results in
      * thousands of large thumbnails being freed, but the memory not actually
      * released by SpaceFM */
-    malloc_trim(0);
+    #if defined (__GLIBC__)
+        malloc_trim(0);
+    #endif
 }
 
 void ptk_file_browser_get_property ( GObject *obj,
@@ -2703,11 +2705,13 @@ void on_dir_file_listed( VFSDir* dir,
     ptk_file_browser_update_model( file_browser );
     file_browser->busy = FALSE;
 
-   /* Ensuring free space at the end of the heap is freed to the OS,
-   * mainly to deal with the possibility that changing the directory results in
-   * thousands of large thumbnails being freed, but the memory not actually
-   * released by SpaceFM */
-   malloc_trim(0);
+    /* Ensuring free space at the end of the heap is freed to the OS,
+     * mainly to deal with the possibility that changing the directory results in
+     * thousands of large thumbnails being freed, but the memory not actually
+     * released by SpaceFM */
+    #if defined (__GLIBC__)
+        malloc_trim(0);
+    #endif
 
     g_signal_emit( file_browser, signals[ AFTER_CHDIR_SIGNAL ], 0 );
     //g_signal_emit( file_browser, signals[ CONTENT_CHANGE_SIGNAL ], 0 );
@@ -4556,7 +4560,9 @@ void ptk_file_browser_refresh( GtkWidget* item, PtkFileBrowser* file_browser )
     /* Ensuring free space at the end of the heap is freed to the OS,
      * mainly to deal with the possibility thousands of large thumbnails
      * have been freed but the memory not actually released by SpaceFM */
-    malloc_trim(0);
+    #if defined (__GLIBC__)
+        malloc_trim(0);
+    #endif
 
     // begin load dir
     file_browser->busy = TRUE;

--- a/src/vfs/vfs-dir.c
+++ b/src/vfs/vfs-dir.c
@@ -21,7 +21,11 @@
 #include <string.h>
 
 #include <fcntl.h>  /* for open() */
+
+#if defined (__GLIBC__)
 #include <malloc.h> /* for malloc_trim */
+#endif
+
 #include <unistd.h> /* for read */
 #include "vfs-volume.h"
 
@@ -1193,7 +1197,9 @@ void vfs_dir_unload_thumbnails( VFSDir* dir, gboolean is_big )
     /* Ensuring free space at the end of the heap is freed to the OS,
      * mainly to deal with the possibility thousands of large thumbnails
      * have been freed but the memory not actually released by SpaceFM */
-    malloc_trim(0);
+    #if defined (__GLIBC__)
+	malloc_trim(0);
+    #endif
 }
 
 //sfm added mime change timer


### PR DESCRIPTION
`malloc_trim` is a GNU extension so this fixes builds that don't use `GlibC` (such as [Musl C](http://www.musl-libc.org/) on [Alpine Linux](http://alpinelinux.org/))