### PR TITLE
Add support for Btrfs clone ioctl

### DIFF
--- a/README
+++ b/README
@@ -98,6 +98,10 @@ DEPENDENCIES
 
     Also, if you want to use startup notification: libstartup-notification0-dev
 
+    If you want to use clone in Btrfs when copying (as in cp --reflink):
+    btrfs-tools (btrfs-progs on ArchLinux and maybe others), only for compiling
+    Linux kernel >= 3.10, only works on Btrfs filesystem
+
     For optional dbus support: dbus libdbus-1-3 libdbus-1-dev
 
     RECOMMENDED: udevil|pmount|udisks gksu|kdesu|ktsuss|lxqt-sudo eject lsof

--- a/configure
+++ b/configure
@@ -1524,8 +1524,8 @@ Optional Features:
                           (default: enable)
   --enable-pixmaps        use share/pixmaps dir instead of share/icons dir to
                           store icons (default: disable)
-  --enable-btrfs-clone    try to use btrfs clone ioctl to copy files (default:
-                          disable)
+  --disable-btrfs-clone   try to use btrfs clone ioctl to copy files (default:
+                          enable if installed)
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -15591,9 +15591,8 @@ fi
 if test "${enable_btrfs_clone+set}" = set; then :
   enableval=$enable_btrfs_clone; use_btrfs_clone=$enableval
 else
-  use_btrfs_clone="no"
+  use_btrfs_clone="yes"
 fi
-
 
 if test x"$use_btrfs_clone" = x"yes"; then
   for ac_header in sys/ioctl.h btrfs/ioctl.h
@@ -15604,15 +15603,18 @@ if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
 #define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
 _ACEOF
-
-$as_echo "#define USE_BTRFS_CLONE 1" >>confdefs.h
-
+ use_btrfs_clone="yes"
 else
-  as_fn_error $? "Fatal Error: btrfs headers not found" "$LINENO" 5
+  use_btrfs_clone="no"
 fi
 
 done
 
+  if test x"$use_btrfs_clone" = x"yes"; then
+
+$as_echo "#define HAVE_BTRFS_CLONE 1" >>confdefs.h
+
+  fi
 fi
 
 CPPFLAGS="$CPPFLAGS -fstrict-aliasing -fmessage-length=0"
@@ -18686,6 +18688,7 @@ fi
 echo Desktop manager integration.................. : $desktop_integration
 echo Startup notification......................... : $use_sn
 echo Video thumbnail support...................... : $video_thumbnails
+echo Btrfs clone support.......................... : $use_btrfs_clone
 echo
 echo 'Homepage: http://ignorantguru.github.io/spacefm/'
 echo

--- a/configure
+++ b/configure
@@ -847,6 +847,7 @@ with_preferable_sudo
 enable_desktop_integration
 enable_video_thumbnails
 enable_pixmaps
+enable_btrfs_clone
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1523,6 +1524,8 @@ Optional Features:
                           (default: enable)
   --enable-pixmaps        use share/pixmaps dir instead of share/icons dir to
                           store icons (default: disable)
+  --enable-btrfs-clone    try to use btrfs clone ioctl to copy files (default:
+                          disable)
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -15583,6 +15586,34 @@ else
   NO_PIXMAPS_FALSE=
 fi
 
+
+# Check whether --enable-btrfs-clone was given.
+if test "${enable_btrfs_clone+set}" = set; then :
+  enableval=$enable_btrfs_clone; use_btrfs_clone=$enableval
+else
+  use_btrfs_clone="no"
+fi
+
+
+if test x"$use_btrfs_clone" = x"yes"; then
+  for ac_header in sys/ioctl.h btrfs/ioctl.h
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
+
+$as_echo "#define USE_BTRFS_CLONE 1" >>confdefs.h
+
+else
+  as_fn_error $? "Fatal Error: btrfs headers not found" "$LINENO" 5
+fi
+
+done
+
+fi
 
 CPPFLAGS="$CPPFLAGS -fstrict-aliasing -fmessage-length=0"
 

--- a/configure.ac
+++ b/configure.ac
@@ -275,14 +275,14 @@ AM_CONDITIONAL(NO_PIXMAPS, test ! x"$use_pixmaps" = x"yes")
 
 AC_ARG_ENABLE(
     [btrfs-clone],
-    AS_HELP_STRING([--enable-btrfs-clone],
-        [try to use btrfs clone ioctl to copy files (default: disable)]),
-    use_btrfs_clone=$enableval, use_btrfs_clone="no")
-
+    AS_HELP_STRING([--disable-btrfs-clone],
+        [try to use btrfs clone ioctl to copy files (default: enable if installed)]),
+    use_btrfs_clone=$enableval, use_btrfs_clone="yes")
 if test x"$use_btrfs_clone" = x"yes"; then
-  AC_CHECK_HEADERS([sys/ioctl.h btrfs/ioctl.h],
-        AC_DEFINE(USE_BTRFS_CLONE, 1, [Whether to enable btrfs clone]),
-        AC_MSG_ERROR([Fatal Error: btrfs headers not found]))
+  AC_CHECK_HEADERS([sys/ioctl.h btrfs/ioctl.h], use_btrfs_clone="yes", use_btrfs_clone="no")
+  if test x"$use_btrfs_clone" = x"yes"; then
+    AC_DEFINE(HAVE_BTRFS_CLONE, 1, [Use Btrfs clone])
+  fi
 fi
 
 dnl advanced compiler tweaking
@@ -367,6 +367,7 @@ fi
 echo Desktop manager integration.................. : $desktop_integration
 echo Startup notification......................... : $use_sn
 echo Video thumbnail support...................... : $video_thumbnails
+echo Btrfs clone support.......................... : $use_btrfs_clone
 echo
 echo 'Homepage: http://ignorantguru.github.io/spacefm/'
 echo

--- a/configure.ac
+++ b/configure.ac
@@ -273,6 +273,18 @@ AC_ARG_ENABLE(
     use_pixmaps=$enableval, use_pixmaps="no")
 AM_CONDITIONAL(NO_PIXMAPS, test ! x"$use_pixmaps" = x"yes")
 
+AC_ARG_ENABLE(
+    [btrfs-clone],
+    AS_HELP_STRING([--enable-btrfs-clone],
+        [try to use btrfs clone ioctl to copy files (default: disable)]),
+    use_btrfs_clone=$enableval, use_btrfs_clone="no")
+
+if test x"$use_btrfs_clone" = x"yes"; then
+  AC_CHECK_HEADERS([sys/ioctl.h btrfs/ioctl.h],
+        AC_DEFINE(USE_BTRFS_CLONE, 1, [Whether to enable btrfs clone]),
+        AC_MSG_ERROR([Fatal Error: btrfs headers not found]))
+fi
+
 dnl advanced compiler tweaking
 CPPFLAGS="$CPPFLAGS -fstrict-aliasing -fmessage-length=0"
 

--- a/src/vfs/vfs-file-task.c
+++ b/src/vfs/vfs-file-task.c
@@ -38,7 +38,7 @@
 #include "desktop-window.h"
 #include "vfs-volume.h"
 
-#ifdef USE_BTRFS_CLONE
+#ifdef HAVE_BTRFS_CLONE
 #include <sys/ioctl.h>
 #include <btrfs/ioctl.h>
 #endif
@@ -570,7 +570,7 @@ vfs_file_task_do_copy( VFSFileTask* task,
                 //if ( task->avoid_changes )
                 //    emit_created( dest_file );
                 struct utimbuf times;
-#ifdef USE_BTRFS_CLONE
+#ifdef HAVE_BTRFS_CLONE
                 // Try to copy using BTRFS Clone ioctl first for O(1) perf
                 // on fail, copy using the traditional method
                 if ( ioctl( wfd, BTRFS_IOC_CLONE, rfd ) == 0 )
@@ -603,7 +603,7 @@ vfs_file_task_do_copy( VFSFileTask* task,
                             break;
                         }
                     }
-#ifdef USE_BTRFS_CLONE
+#ifdef HAVE_BTRFS_CLONE
                 }
 #endif
                 close( wfd );


### PR DESCRIPTION
Btrfs clone ioctl can be used for O(1) copying within a file system
utilizing copy-on-write.

Passing --enable-btrfs-clone to ./configure enables this feature.

The feature is dependent on the "btrfs/ioctl.h" header which is part of
btrfs-progs.

vfs_file_task_do_copy is modified to always try to call the ioctl,
and fall back to the regular copying method if it fails.
