### PR TITLE
Avoid X-specific calls under Wayland

### DIFF
--- a/src/desktop/desktop.c
+++ b/src/desktop/desktop.c
@@ -27,6 +27,7 @@
 #ifdef DESKTOP_INTEGRATION
 
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 //#include "fm-desktop.h"
 
 #include "vfs-file-info.h"
@@ -74,6 +75,12 @@ void fm_turn_on_desktop_icons(gboolean transparent)
     gint i;
     int big = 0;
 
+    gdpy = gdk_display_get_default();
+#if GTK_CHECK_VERSION (3, 0, 0)
+    if( ! GDK_IS_X11_DISPLAY( gdpy ) )
+        return;
+#endif
+
     if( ! group )
         group = gtk_window_group_new();
 
@@ -81,8 +88,6 @@ void fm_turn_on_desktop_icons(gboolean transparent)
                                     G_CALLBACK(on_icon_theme_changed), NULL );
 
     vfs_mime_type_get_icon_size( &big, NULL );
-
-    gdpy = gdk_display_get_default();
 
     n_screens = gdk_display_get_n_screens( gdpy );
     desktops = g_new( GtkWidget *, n_screens );

--- a/src/desktop/working-area.c
+++ b/src/desktop/working-area.c
@@ -22,6 +22,7 @@
   This piece of code detecting working area is got from Guifications, a plug-in for Gaim.
 */
 
+# include <gtk/gtk.h>
 # include <gdk/gdk.h>
 # include <gdk/gdkx.h>
 # include <X11/Xlib.h>
@@ -43,7 +44,11 @@ gf_display_get_workarea(GdkScreen* g_screen, GdkRectangle *rect) {
 
 	/* get the gdk display */
 	g_display = gdk_display_get_default();
+#if GTK_CHECK_VERSION(3, 0, 0)
+	if(!g_display || !GDK_IS_X11_DISPLAY(g_display))
+#else
 	if(!g_display)
+#endif
 		return FALSE;
 
 	/* get the x display from the gdk display */

--- a/src/main-window.c
+++ b/src/main-window.c
@@ -4175,7 +4175,11 @@ static long get_desktop_index( GtkWindow* win )
     {
         // get current desktop
         display = gdk_display_get_default();
+#if GTK_CHECK_VERSION (3, 0, 0)
+        if ( display && GDK_IS_X11_DISPLAY (display ) )
+#else
         if ( display )
+#endif
             window = gdk_x11_window_lookup_for_display( display,
                                     gdk_x11_get_default_root_xwindow() );
     }

--- a/src/main.c
+++ b/src/main.c
@@ -329,12 +329,23 @@ gboolean on_socket_event( GIOChannel* ioc, GIOCondition cond, gpointer data )
 
 void get_socket_name_nogdk( char* buf, int len )
 {
-    char* dpy = g_strdup( g_getenv( "DISPLAY" ) );
-    if ( dpy && !strcmp( dpy, ":0.0" ) )
+    char* dpy;
+#if GTK_CHECK_VERSION(3, 0, 0)
+    const char* tmp = g_getenv( "WAYLAND_DISPLAY" );
+    if ( tmp )
+        dpy = g_strdup( tmp );
+    else
+#else
+    if ( TRUE )
+#endif
     {
-        // treat :0.0 as :0 to prevent multiple instances on screen 0
-        g_free( dpy );
-        dpy = g_strdup( ":0" );
+        dpy = g_strdup( g_getenv( "DISPLAY" ) );
+        if ( dpy && !strcmp( dpy, ":0.0" ) )
+        {
+            // treat :0.0 as :0 to prevent multiple instances on screen 0
+            g_free( dpy );
+            dpy = g_strdup( ":0" );
+        }
     }
     g_snprintf( buf, len, "%s/.spacefm-socket%s-%s", xset_get_tmp_dir(),
                                                      dpy,


### PR DESCRIPTION
This is a very naive implementation of Wayland support: it assumes a non-X11 display is a Wayland display.

Either WAYLAND_DISPLAY or DISPLAY is passed to children depending on the GTK+ backend used by spacefm, so children of spacefm use Xwayland if spacefm itself does.

The desktop is always disabled under Wayland.