### PR TITLE
Fix crash when unmounting volumes

### DIFF
--- a/src/vfs/vfs-file-monitor.c
+++ b/src/vfs/vfs-file-monitor.c
@@ -405,11 +405,17 @@ static void dispatch_event( VFSFileMonitor * monitor,
     VFSFileMonitorCallbackEntry * cb;
     VFSFileMonitorCallback func;
     int i;
+    int num_callbacks;
     /* Call the callback functions */
     if ( monitor->callbacks && monitor->callbacks->len )
     {
         cb = ( VFSFileMonitorCallbackEntry* ) monitor->callbacks->data;
-        for ( i = 0; i < monitor->callbacks->len; ++i )
+        /*
+          Store the number of callbacks beforehand, as monitor may be destroyed
+          during the last iteration
+        */
+        num_callbacks = monitor->callbacks->len;
+        for ( i = 0; i < num_callbacks; ++i )
         {
             func = cb[ i ].callback;
             func( monitor, evt, file_name, cb[ i ].user_data );


### PR DESCRIPTION
This was a use-after-free of `monitor`, which gets freed by `vfs_dir_finalize()`:
https://github.com/IgnorantGuru/spacefm/blob/e6f291858067e73db44fb57c90e4efb97b088ac8/src/vfs/vfs-dir.c#L228-L233
I'm not sure why the VFSDir gets destroyed at that point, but it was probably some internal GLib change, as usual.

Fixes #819.